### PR TITLE
Added code to check if Bill had been ratified

### DIFF
--- a/ncleg/spiders/nc_leg_bills_spider.py
+++ b/ncleg/spiders/nc_leg_bills_spider.py
@@ -53,7 +53,15 @@ class NcLegBillsSpider(scrapy.Spider):
         item['keywords'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[6]/td/div/text()').re('[^,]+')
         item['counties'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[4]/td/text()').re('[^,]+')
         item['statutes'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[5]/td/div/text()').re('[^,]+')
-
+        
+        # Check to see if bill has been ratified 
+        # (not necessarily vetoed)
+        ratified_arr = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[1]/table//tr//td//text()').re('[^,]+')
+        if "Ratified" in ratified_arr:
+            item['is_ratified'] = True
+        else:
+            item['is_ratified'] = False
+        
         # In 2017 member names are embedded in links
         if (self.session == '2017'):
             item['sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a/text()').extract()
@@ -66,3 +74,4 @@ class NcLegBillsSpider(scrapy.Spider):
                 del sponsors[primary]
             item['sponsors'] = sponsors
         yield item
+

--- a/ncleg/spiders/nc_leg_bills_spider.py
+++ b/ncleg/spiders/nc_leg_bills_spider.py
@@ -54,14 +54,9 @@ class NcLegBillsSpider(scrapy.Spider):
         item['counties'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[4]/td/text()').re('[^,]+')
         item['statutes'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[5]/td/div/text()').re('[^,]+')
         
-        # Check to see if bill has been ratified 
-        # (not necessarily vetoed)
-        ratified_arr = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[1]/table//tr//td//text()').re('[^,]+')
-        if "Ratified" in ratified_arr:
-            item['is_ratified'] = True
-        else:
-            item['is_ratified'] = False
-        
+        # Check to see if bill had been ratified 
+        item['is_ratified'] = self.isRatified(response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[1]/table//tr//td//text()').re('[^,]+'))
+       
         # In 2017 member names are embedded in links
         if (self.session == '2017'):
             item['sponsors'] = response.xpath('//div[@id = "mainBody"]/table[2]/tr/td[3]/table/tr[2]/td/a/text()').extract()
@@ -74,4 +69,9 @@ class NcLegBillsSpider(scrapy.Spider):
                 del sponsors[primary]
             item['sponsors'] = sponsors
         yield item
+
+    def isRatified(self, arr):
+        if "Ratified" in arr:
+            return True
+        return False
 


### PR DESCRIPTION

So far, this will only check if a bill had been ratified, not necessarily if the ratification is currently withdrawn.  I can add some additional code when working on the other two fields, but I think this satisfies the is ratified requirement thus far.

Obviously, in the future, I will add something to switch the ratification back to false if the ratification has been rescinded.  